### PR TITLE
Add an xsd to `phpcs` config

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/3.7.0/phpcs.xsd"
+        name="Laminas coding standard">
     <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
 
     <!-- Paths to check -->


### PR DESCRIPTION
An XSD is no available in distributions of PHPCS v2.x

This patch adds a remote XSD in the hope it will make schema validation pass in CI